### PR TITLE
Update go version to fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-  - "1.6"
+  - "1.11.x"
   - "tip"
 env:
   - EVM_EMACS=emacs-24.4-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ env:
   - EVM_EMACS=emacs-24.5-travis
   - EVM_EMACS=emacs-25.1-travis
 before_install:
-  - go get -u golang.org/x/tools/cmd/godoc
   - export PATH=$HOME/gopath/bin:$PATH
   - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
   - evm install $EVM_EMACS --use --skip


### PR DESCRIPTION
It seems that go 1.6 no longer works on Travis CI:
https://github.com/cweill/gotests/issues/67

The CI in the original repo breaks. Could you please adapt my CI fix and update your [PR there](https://github.com/syohex/emacs-go-impl/pull/9)?